### PR TITLE
Add support for Spring

### DIFF
--- a/lib/safer_rails_console/colors.rb
+++ b/lib/safer_rails_console/colors.rb
@@ -10,8 +10,12 @@ module SaferRailsConsole
     CYAN = 36
     WHITE = 37
 
-    def color_text(text, color_code)
+    def self.color_text(text, color_code)
       "\e[#{color_code}m#{text}\e[0m"
+    end
+
+    def color_text(text, color_code)
+      SaferRailsConsole::Colors.color_text(text, color_code)
     end
   end
 end

--- a/lib/safer_rails_console/colors.rb
+++ b/lib/safer_rails_console/colors.rb
@@ -10,12 +10,8 @@ module SaferRailsConsole
     CYAN = 36
     WHITE = 37
 
-    def self.color_text(text, color_code)
-      "\e[#{color_code}m#{text}\e[0m"
-    end
-
     def color_text(text, color_code)
-      SaferRailsConsole::Colors.color_text(text, color_code)
+      "\e[#{color_code}m#{text}\e[0m"
     end
   end
 end

--- a/lib/safer_rails_console/console.rb
+++ b/lib/safer_rails_console/console.rb
@@ -1,20 +1,12 @@
 module SaferRailsConsole
   module Console
     class << self
-      include SaferRailsConsole::Colors
-
       def initialize_sandbox
         require 'safer_rails_console/patches/sandbox'
       end
 
       def print_warning
-        puts color_text(SaferRailsConsole.config.warn_text, SaferRailsConsole.prompt_color) # rubocop:disable Rails/Output
-      end
-
-      def sandbox_prompt_user_input
-        puts "Defaulting the console into sandbox mode.\nType 'disable' to disable. Anything else will begin a sandboxed session:" # rubocop:disable Rails/Output
-        input = gets.strip
-        input != 'disable'
+        puts SaferRailsConsole::Colors.color_text(SaferRailsConsole.config.warn_text, SaferRailsConsole.prompt_color) # rubocop:disable Rails/Output
       end
     end
   end

--- a/lib/safer_rails_console/console.rb
+++ b/lib/safer_rails_console/console.rb
@@ -16,6 +16,12 @@ module SaferRailsConsole
         gem_root = gem.gem_dir
         ARGV.push '-r', File.join(gem_root, 'lib', 'safer_rails_console', 'consoles', "#{SaferRailsConsole.config.console}.rb")
       end
+
+      def sandbox_user_prompt
+        puts "Defaulting the console into sandbox mode.\nType 'disable' to disable. Anything else will begin a sandboxed session:" # rubocop:disable Rails/Output
+        input = gets.strip
+        input != 'disable'
+      end
     end
   end
 end

--- a/lib/safer_rails_console/console.rb
+++ b/lib/safer_rails_console/console.rb
@@ -8,6 +8,12 @@ module SaferRailsConsole
       def print_warning
         puts SaferRailsConsole::Colors.color_text(SaferRailsConsole.config.warn_text, SaferRailsConsole.prompt_color) # rubocop:disable Rails/Output
       end
+
+      def load_config
+        gem = Gem::Specification.find_by_name('safer_rails_console') # rubocop:disable Rails/DynamicFindBy
+        gem_root = gem.gem_dir
+        ARGV.push '-r', File.join(gem_root, 'lib', 'safer_rails_console', 'consoles', "#{SaferRailsConsole.config.console}.rb")
+      end
     end
   end
 end

--- a/lib/safer_rails_console/console.rb
+++ b/lib/safer_rails_console/console.rb
@@ -1,12 +1,14 @@
 module SaferRailsConsole
   module Console
     class << self
+      include SaferRailsConsole::Colors
+
       def initialize_sandbox
         require 'safer_rails_console/patches/sandbox'
       end
 
       def print_warning
-        puts SaferRailsConsole::Colors.color_text(SaferRailsConsole.config.warn_text, SaferRailsConsole.prompt_color) # rubocop:disable Rails/Output
+        puts color_text(SaferRailsConsole.config.warn_text, SaferRailsConsole.prompt_color) # rubocop:disable Rails/Output
       end
 
       def load_config

--- a/lib/safer_rails_console/patches/railtie/console.rb
+++ b/lib/safer_rails_console/patches/railtie/console.rb
@@ -1,7 +1,0 @@
-::Rails::Application.class_eval do
-  console do
-    gem = Gem::Specification.find_by_name('safer_rails_console') # rubocop:disable Rails/DynamicFindBy
-    gem_root = gem.gem_dir
-    ARGV.push '-r', File.join(gem_root, 'lib', 'safer_rails_console', 'consoles', "#{SaferRailsConsole.config.console}.rb")
-  end
-end

--- a/lib/safer_rails_console/patches/railtie/sandbox.rb
+++ b/lib/safer_rails_console/patches/railtie/sandbox.rb
@@ -17,8 +17,7 @@ module SaferRailsConsole
           end
 
           def sandbox_user_prompt
-            puts "Defaulting the console into sandbox mode.\n"\
-                 "Type 'disable' to disable. Anything else will begin a sandboxed session:" # rubocop:disable Rails/Output
+            puts "Defaulting the console into sandbox mode.\nType 'disable' to disable. Anything else will begin a sandboxed session:" # rubocop:disable Rails/Output
             input = gets.strip
             input != 'disable'
           end

--- a/lib/safer_rails_console/patches/railtie/sandbox.rb
+++ b/lib/safer_rails_console/patches/railtie/sandbox.rb
@@ -11,15 +11,9 @@ module SaferRailsConsole
             options = args.last
 
             options[:sandbox] = SaferRailsConsole.sandbox_environment? if options[:sandbox].nil?
-            options[:sandbox] = sandbox_user_prompt if SaferRailsConsole.sandbox_environment? && SaferRailsConsole.config.sandbox_prompt
+            options[:sandbox] = SaferRailsConsole::Console.sandbox_user_prompt if SaferRailsConsole.sandbox_environment? && SaferRailsConsole.config.sandbox_prompt
 
             super *args
-          end
-
-          def sandbox_user_prompt
-            puts "Defaulting the console into sandbox mode.\nType 'disable' to disable. Anything else will begin a sandboxed session:" # rubocop:disable Rails/Output
-            input = gets.strip
-            input != 'disable'
           end
         end
       end

--- a/lib/safer_rails_console/patches/railtie/sandbox.rb
+++ b/lib/safer_rails_console/patches/railtie/sandbox.rb
@@ -27,9 +27,13 @@ module SaferRailsConsole
   end
 end
 
-if defined?(Spring) && SaferRailsConsole.sandbox_environment?
-  puts "Warning: environment-based automatic sandboxing does not work with Spring (from 'safer_rails_console/patches/railtie/sandbox')" # rubocop:disable Rails/Output
-elsif SaferRailsConsole::RailsVersion.supported?
+if SaferRailsConsole::RailsVersion.supported?
+  if SaferRailsConsole::RailsVersion.five_one?
+    require 'rails/commands/console/console_command'
+  else
+    require 'rails/commands/console'
+  end
+
   ::Rails::Console.singleton_class.prepend(SaferRailsConsole::Patches::Sandbox::Rails::Console)
 else
   raise "No sandbox patch for rails version '#{::Rails.version}' exists. "\

--- a/lib/safer_rails_console/railtie.rb
+++ b/lib/safer_rails_console/railtie.rb
@@ -18,15 +18,7 @@ module SaferRailsConsole
     console do
       SaferRailsConsole::Console.initialize_sandbox if ::Rails.application.sandbox
       SaferRailsConsole::Console.print_warning if SaferRailsConsole.warn_environment?
-      load_console_config
-    end
-
-    private
-
-    def load_console_config
-      gem = Gem::Specification.find_by_name('safer_rails_console') # rubocop:disable Rails/DynamicFindBy
-      gem_root = gem.gem_dir
-      ARGV.push '-r', File.join(gem_root, 'lib', 'safer_rails_console', 'consoles', "#{SaferRailsConsole.config.console}.rb")
+      SaferRailsConsole::Console.load_config
     end
   end
 end

--- a/lib/safer_rails_console/railtie.rb
+++ b/lib/safer_rails_console/railtie.rb
@@ -12,7 +12,21 @@ module SaferRailsConsole
     end
 
     config.after_initialize do
-      require 'safer_rails_console/patches/railtie' if defined?(::Rails::Console)
+      require 'safer_rails_console/patches/railtie'
+    end
+
+    console do
+      SaferRailsConsole::Console.initialize_sandbox if ::Rails.application.sandbox
+      SaferRailsConsole::Console.print_warning if SaferRailsConsole.warn_environment?
+      load_console_config
+    end
+
+    private
+
+    def load_console_config
+      gem = Gem::Specification.find_by_name('safer_rails_console') # rubocop:disable Rails/DynamicFindBy
+      gem_root = gem.gem_dir
+      ARGV.push '-r', File.join(gem_root, 'lib', 'safer_rails_console', 'consoles', "#{SaferRailsConsole.config.console}.rb")
     end
   end
 end

--- a/spec/integration/patches/railtie_spec.rb
+++ b/spec/integration/patches/railtie_spec.rb
@@ -5,12 +5,6 @@ describe "Integration: patches/railtie" do
     cmd.stdout
   end
 
-  context "console" do
-    it "loads the console config into the selected console" do
-      expect(cmd_stdout).to include('sandbox')
-    end
-  end
-
   context "sandbox" do
     let(:console_commands) { ['exit'] }
     let(:cmd_stdout) do

--- a/spec/safer_rails_console/colors_spec.rb
+++ b/spec/safer_rails_console/colors_spec.rb
@@ -7,6 +7,9 @@ describe SaferRailsConsole::Colors do
     ClassWithColors
   end
 
+  let(:sample_text) { 'some input' }
+  let(:expected_output) { "\e[#{described_class::RED}m#{sample_text}\e[0m" }
+
   specify "color constants are defined" do
     expect(described_class::NONE).to eq(0)
     expect(described_class::RED).to eq(31)
@@ -18,10 +21,13 @@ describe SaferRailsConsole::Colors do
     expect(described_class::WHITE).to eq(37)
   end
 
-  context "#color_text" do
-    let(:sample_text) { 'some input' }
-    let(:expected_output) { "\e[#{described_class::RED}m#{sample_text}\e[0m" }
+  context ".color_text" do
+    it "outputs colored text" do
+      expect(described_class.color_text(sample_text, described_class::RED)).to eq(expected_output)
+    end
+  end
 
+  context "#color_text" do
     it "is defined when included in a class" do
       expect(class_with_colors.method_defined?(:color_text)).to eq(true)
     end

--- a/spec/safer_rails_console/colors_spec.rb
+++ b/spec/safer_rails_console/colors_spec.rb
@@ -21,12 +21,6 @@ describe SaferRailsConsole::Colors do
     expect(described_class::WHITE).to eq(37)
   end
 
-  context ".color_text" do
-    it "outputs colored text" do
-      expect(described_class.color_text(sample_text, described_class::RED)).to eq(expected_output)
-    end
-  end
-
   context "#color_text" do
     it "is defined when included in a class" do
       expect(class_with_colors.method_defined?(:color_text)).to eq(true)

--- a/spec/safer_rails_console/console_spec.rb
+++ b/spec/safer_rails_console/console_spec.rb
@@ -24,4 +24,22 @@ describe SaferRailsConsole::Console do
       expect(ARGV.any? { |arg| arg.include?('irb.rb') }).to be(true)
     end
   end
+
+  context ".sandbox_prompt_user_input" do
+    context "input: 'disable'" do
+      before { allow(described_class).to receive(:gets).and_return('disable') }
+
+      it "disables the sandbox" do
+        expect(described_class.sandbox_prompt_user_input).to eq(false)
+      end
+    end
+
+    context "input: 'something else'" do
+      before { allow(described_class).to receive(:gets).and_return('something else') }
+
+      it "enables the sandbox" do
+        expect(described_class.sandbox_prompt_user_input).to eq(true)
+      end
+    end
+  end
 end

--- a/spec/safer_rails_console/console_spec.rb
+++ b/spec/safer_rails_console/console_spec.rb
@@ -16,4 +16,12 @@ describe SaferRailsConsole::Console do
       expect { described_class.print_warning }.to output(expected_output).to_stdout
     end
   end
+
+  context ".load_config" do
+    before { described_class.load_config }
+
+    it "adds console config file to ARGV" do
+      expect(ARGV.any? { |arg| arg.include?('irb.rb') }).to be(true)
+    end
+  end
 end

--- a/spec/safer_rails_console/console_spec.rb
+++ b/spec/safer_rails_console/console_spec.rb
@@ -16,22 +16,4 @@ describe SaferRailsConsole::Console do
       expect { described_class.print_warning }.to output(expected_output).to_stdout
     end
   end
-
-  context ".sandbox_prompt_user_input" do
-    context "input: 'disable'" do
-      before { allow(described_class).to receive(:gets).and_return('disable') }
-
-      it "disables the sandbox" do
-        expect(described_class.sandbox_prompt_user_input).to eq(false)
-      end
-    end
-
-    context "input: 'something else'" do
-      before { allow(described_class).to receive(:gets).and_return('something else') }
-
-      it "enables the sandbox" do
-        expect(described_class.sandbox_prompt_user_input).to eq(true)
-      end
-    end
-  end
 end

--- a/spec/safer_rails_console/console_spec.rb
+++ b/spec/safer_rails_console/console_spec.rb
@@ -25,12 +25,12 @@ describe SaferRailsConsole::Console do
     end
   end
 
-  context ".sandbox_prompt_user_input" do
+  context ".sandbox_user_prompt" do
     context "input: 'disable'" do
       before { allow(described_class).to receive(:gets).and_return('disable') }
 
       it "disables the sandbox" do
-        expect(described_class.sandbox_prompt_user_input).to eq(false)
+        expect(described_class.sandbox_user_prompt).to eq(false)
       end
     end
 
@@ -38,7 +38,7 @@ describe SaferRailsConsole::Console do
       before { allow(described_class).to receive(:gets).and_return('something else') }
 
       it "enables the sandbox" do
-        expect(described_class.sandbox_prompt_user_input).to eq(true)
+        expect(described_class.sandbox_user_prompt).to eq(true)
       end
     end
   end


### PR DESCRIPTION
This PR fixes #6 , and addresses issues discovered in CI in cancelled PR #7 .

Logic is shuffled around to allow this gem to work in Spring.  Spring runs Railtie initializers earlier in the boot process than the standard Rails initialization process does, which our previous check on `if defined?(::Rails::Console)` would always evaluate to `false`.  Instead, we simply always require `rails/commands/console` - `Rails::Console`.

prime: @will89 