### PR TITLE
Dasherize the app name given CamelCase

### DIFF
--- a/lib/safer_rails_console/consoles/irb.rb
+++ b/lib/safer_rails_console/consoles/irb.rb
@@ -1,6 +1,6 @@
 include SaferRailsConsole::Colors
 
-app_name = ::Rails.application.class.parent.to_s.downcase
+app_name = ::Rails.application.class.parent.to_s.underscore.dasherize
 env_name = SaferRailsConsole.environment_name
 status = ::Rails.application.sandbox ? 'sandboxed' : 'unsandboxed'
 color = SaferRailsConsole.prompt_color


### PR DESCRIPTION
An app having the name of "CamelCase" will now be `camel-case` instead of `camelcase` in the prompt.

prime: @skarger 