### PR TITLE
Resolve sqlite3 dependency warning

### DIFF
--- a/safer_rails_console.gemspec
+++ b/safer_rails_console.gemspec
@@ -37,7 +37,7 @@ Gem::Specification.new do |spec|
   spec.add_development_dependency 'rake', '~> 12.0'
   spec.add_development_dependency 'rspec', '~> 3.6'
   spec.add_development_dependency 'salsify_rubocop', '~> 0.48.0'
-  spec.add_development_dependency 'sqlite3', '~> 1.3.13'
+  spec.add_development_dependency 'sqlite3', '~> 1.3'
   spec.add_development_dependency 'wwtd', '~> 1.3'
   spec.add_runtime_dependency 'rails', '>= 4.1', '< 5.2'
 end


### PR DESCRIPTION
This silences a warning that occurs when running `gem release`

```
WARNING:  pessimistic dependency on sqlite3 (~> 1.3.13, development) may be overly strict
  if sqlite3 is semantically versioned, use:
    add_development_dependency 'sqlite3', '~> 1.3', '>= 1.3.13'
```

prime: @skarger  