### PR TITLE
Default sandbox flag to nil in Rails 5.1

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -24,6 +24,5 @@ matrix:
   allow_failures:
     - gemfile: gemfiles/4.1.gemfile
       rvm: 2.4.1
-    - gemfile: gemfiles/5.1.gemfile
 
   fast_finish: true

--- a/lib/safer_rails_console/patches/boot/sandbox_flag.rb
+++ b/lib/safer_rails_console/patches/boot/sandbox_flag.rb
@@ -79,6 +79,7 @@ elsif SaferRailsConsole::RailsVersion.five_zero?
 elsif SaferRailsConsole::RailsVersion.five_one?
   require 'rails/command'
   require 'rails/commands/console/console_command'
+  # Rails 5.1 defaults `sandbox` to `false`, but we need it to NOT have a default value and be `nil` when it is not user-specified
   ::Rails::Command::ConsoleCommand.class_eval do
     remove_class_option :sandbox
     class_option :sandbox, aliases: '-s', type: :boolean, desc: 'Explicitly enable/disable sandbox mode.'

--- a/lib/safer_rails_console/patches/boot/sandbox_flag.rb
+++ b/lib/safer_rails_console/patches/boot/sandbox_flag.rb
@@ -81,7 +81,7 @@ elsif SaferRailsConsole::RailsVersion.five_one?
   require 'rails/commands/console/console_command'
   ::Rails::Command::ConsoleCommand.class_eval do
     remove_class_option :sandbox
-    class_option :sandbox, aliases: "-s", type: :boolean, desc: "Explicitly enable/disable sandbox mode."
+    class_option :sandbox, aliases: '-s', type: :boolean, desc: 'Explicitly enable/disable sandbox mode.'
   end
 else
   unless SaferRailsConsole::RailsVersion.supported?

--- a/lib/safer_rails_console/patches/boot/sandbox_flag.rb
+++ b/lib/safer_rails_console/patches/boot/sandbox_flag.rb
@@ -76,6 +76,13 @@ if SaferRailsConsole::RailsVersion.four_one? || SaferRailsConsole::RailsVersion.
 elsif SaferRailsConsole::RailsVersion.five_zero?
   require 'rails/commands/commands_tasks'
   ::Rails::CommandsTasks.prepend(SaferRailsConsole::Patches::Boot::SandboxFlag::Rails::CommandsTasks50)
+elsif SaferRailsConsole::RailsVersion.five_one?
+  require 'rails/command'
+  require 'rails/commands/console/console_command'
+  ::Rails::Command::ConsoleCommand.class_eval do
+    remove_class_option :sandbox
+    class_option :sandbox, aliases: "-s", type: :boolean, desc: "Explicitly enable/disable sandbox mode."
+  end
 else
   unless SaferRailsConsole::RailsVersion.supported?
     raise "No boot/sandbox_flag patch for rails version '#{::Rails.version}' exists. "\

--- a/lib/safer_rails_console/patches/railtie/sandbox.rb
+++ b/lib/safer_rails_console/patches/railtie/sandbox.rb
@@ -4,10 +4,6 @@ module SaferRailsConsole
       module Rails
         module Console
           def start(*args)
-            if SaferRailsConsole::RailsVersion.five_one? && SaferRailsConsole.sandbox_environment?
-              # TODO: Fix Rails 5.1 support
-            end
-
             options = args.last
 
             options[:sandbox] = SaferRailsConsole.sandbox_environment? if options[:sandbox].nil?

--- a/spec/integration/patches/railtie_spec.rb
+++ b/spec/integration/patches/railtie_spec.rb
@@ -25,7 +25,6 @@ describe "Integration: patches/railtie" do
       end
     end
 
-    # TODO: Fix Rails 5.1 support
     context "RAILS_ENV=production" do
       let(:specified_env) { 'production' }
 


### PR DESCRIPTION
This fixes #4 , as we rely on non-explicit enable/disablement of the sandbox (no `--sandbox` nor `--no-sandbox`) to automatically sandbox environments.

prime: @skarger 