### PR TITLE
Change 'sandboxed' and 'unsandboxed' to 'read-only' and 'writable' and add respective flags

### DIFF
--- a/README.md
+++ b/README.md
@@ -27,11 +27,14 @@ require 'safer_rails_console/patches/boot'
 
 The quickest way to demo this gem is to run `bundle exec rails console --sandbox`.
 
-A way to explicitly enable or disable the sandbox is added to Rails console as a flag with the last install step.
+Several ways to explicitly enable or disable the sandbox are added to Rails console as flags with the last install step.  The order of precedence is `-s`, `-r`, then `-w` if multiple sandbox related flags are specified.
 ```ruby
 bundle exec rails console --help  
 
+Usage: rails console [environment] [options]
     -s, --[no-]sandbox               Explicitly enable/disable sandbox mode.
+    -w, --writable                   Alias for --no-sandbox.
+    -r, --read-only                  Alias for --sandbox.
     -e, --environment=name           Specifies the environment to run this console under (test/development/production).
                                      Default: development
         --debugger                   Enable the debugger.

--- a/lib/safer_rails_console/consoles/irb.rb
+++ b/lib/safer_rails_console/consoles/irb.rb
@@ -2,7 +2,7 @@ include SaferRailsConsole::Colors
 
 app_name = ::Rails.application.class.parent.to_s.underscore.dasherize
 env_name = SaferRailsConsole.environment_name
-status = ::Rails.application.sandbox ? 'sandboxed' : 'unsandboxed'
+status = ::Rails.application.sandbox ? 'read-only' : 'writable'
 color = SaferRailsConsole.prompt_color
 
 prompt = "#{app_name}(#{env_name})(#{status}):%03n:%i"

--- a/lib/safer_rails_console/patches/boot/sandbox_flag.rb
+++ b/lib/safer_rails_console/patches/boot/sandbox_flag.rb
@@ -4,6 +4,16 @@ module SaferRailsConsole
   module Patches
     module Boot
       module SandboxFlag
+        def self.console_options(opt)
+          opt.banner = 'Usage: rails console [environment] [options]'
+          opt.on('-s', '--[no-]sandbox', 'Explicitly enable/disable sandbox mode.') { |v| options[:sandbox] = v }
+          opt.on('-w', '--writable', 'Alias for --no-sandbox.') { |v| options[:writable] = v }
+          opt.on('-r', '--read-only', 'Alias for --sandbox.') { |v| options[:'read-only'] = v }
+          opt.on('-e', '--environment=name', String,
+                 'Specifies the environment to run this console under (test/development/production).',
+                 'Default: development') { |v| options[:environment] = v.strip }
+        end
+
         module Rails
           module CommandsTasks4
             def console
@@ -18,13 +28,7 @@ module SaferRailsConsole
               options = {}
 
               OptionParser.new do |opt|
-                opt.banner = 'Usage: rails console [environment] [options]'
-                opt.on('-s', '--[no-]sandbox', 'Explicitly enable/disable sandbox mode.') { |v| options[:sandbox] = v }
-                opt.on('-w', '--writable', 'Alias for --no-sandbox.') { |v| options[:writable] = v }
-                opt.on('-r', '--read-only', 'Alias for --sandbox.') { |v| options[:'read-only'] = v }
-                opt.on('-e', '--environment=name', String,
-                       'Specifies the environment to run this console under (test/development/production).',
-                       'Default: development') { |v| options[:environment] = v.strip }
+                ::SaferRailsConsole::Patches::Boot::SandboxFlag.console_options(opt)
                 opt.on('--debugger', 'Enable the debugger.') { |v| options[:debugger] = v }
                 opt.parse!(arguments)
               end
@@ -55,13 +59,7 @@ module SaferRailsConsole
               options = {}
 
               OptionParser.new do |opt|
-                opt.banner = 'Usage: rails console [environment] [options]'
-                opt.on('-s', '--[no-]sandbox', 'Explicitly enable/disable sandbox mode.') { |v| options[:sandbox] = v }
-                opt.on('-w', '--writable', 'Alias for --no-sandbox.') { |v| options[:writable] = v }
-                opt.on('-r', '--read-only', 'Alias for --sandbox.') { |v| options[:'read-only'] = v }
-                opt.on('-e', '--environment=name', String,
-                       'Specifies the environment to run this console under (test/development/production).',
-                       'Default: development') { |v| options[:environment] = v.strip }
+                ::SaferRailsConsole::Patches::Boot::SandboxFlag.console_options(opt)
                 opt.parse!(arguments)
               end
 

--- a/lib/safer_rails_console/patches/boot/sandbox_flag.rb
+++ b/lib/safer_rails_console/patches/boot/sandbox_flag.rb
@@ -4,7 +4,7 @@ module SaferRailsConsole
   module Patches
     module Boot
       module SandboxFlag
-        def self.console_options(opt)
+        def self.console_options(opt, options = {})
           opt.banner = 'Usage: rails console [environment] [options]'
           opt.on('-s', '--[no-]sandbox', 'Explicitly enable/disable sandbox mode.') { |v| options[:sandbox] = v }
           opt.on('-w', '--writable', 'Alias for --no-sandbox.') { |v| options[:writable] = v }
@@ -28,7 +28,7 @@ module SaferRailsConsole
               options = {}
 
               OptionParser.new do |opt|
-                ::SaferRailsConsole::Patches::Boot::SandboxFlag.console_options(opt)
+                ::SaferRailsConsole::Patches::Boot::SandboxFlag.console_options(opt, options)
                 opt.on('--debugger', 'Enable the debugger.') { |v| options[:debugger] = v }
                 opt.parse!(arguments)
               end

--- a/lib/safer_rails_console/patches/boot/sandbox_flag.rb
+++ b/lib/safer_rails_console/patches/boot/sandbox_flag.rb
@@ -59,7 +59,7 @@ module SaferRailsConsole
               options = {}
 
               OptionParser.new do |opt|
-                ::SaferRailsConsole::Patches::Boot::SandboxFlag.console_options(opt)
+                ::SaferRailsConsole::Patches::Boot::SandboxFlag.console_options(opt, options)
                 opt.parse!(arguments)
               end
 

--- a/lib/safer_rails_console/patches/boot/sandbox_flag.rb
+++ b/lib/safer_rails_console/patches/boot/sandbox_flag.rb
@@ -20,6 +20,8 @@ module SaferRailsConsole
               OptionParser.new do |opt|
                 opt.banner = 'Usage: rails console [environment] [options]'
                 opt.on('-s', '--[no-]sandbox', 'Explicitly enable/disable sandbox mode.') { |v| options[:sandbox] = v }
+                opt.on('-w', '--writable', 'Alias for --no-sandbox.') { |v| options[:writable] = v }
+                opt.on('-r', '--read-only', 'Alias for --sandbox.') { |v| options[:'read-only'] = v }
                 opt.on('-e', '--environment=name', String,
                        'Specifies the environment to run this console under (test/development/production).',
                        'Default: development') { |v| options[:environment] = v.strip }
@@ -55,6 +57,8 @@ module SaferRailsConsole
               OptionParser.new do |opt|
                 opt.banner = 'Usage: rails console [environment] [options]'
                 opt.on('-s', '--[no-]sandbox', 'Explicitly enable/disable sandbox mode.') { |v| options[:sandbox] = v }
+                opt.on('-w', '--writable', 'Alias for --no-sandbox.') { |v| options[:writable] = v }
+                opt.on('-r', '--read-only', 'Alias for --sandbox.') { |v| options[:'read-only'] = v }
                 opt.on('-e', '--environment=name', String,
                        'Specifies the environment to run this console under (test/development/production).',
                        'Default: development') { |v| options[:environment] = v.strip }
@@ -83,6 +87,8 @@ elsif SaferRailsConsole::RailsVersion.five_one?
   ::Rails::Command::ConsoleCommand.class_eval do
     remove_class_option :sandbox
     class_option :sandbox, aliases: '-s', type: :boolean, desc: 'Explicitly enable/disable sandbox mode.'
+    class_option :writable, aliases: '-w', type: :boolean, desc: 'Alias for --no-sandbox.'
+    class_option :'read-only', aliases: '-r', type: :boolean, desc: 'Alias for --sandbox.'
   end
 else
   unless SaferRailsConsole::RailsVersion.supported?

--- a/lib/safer_rails_console/patches/railtie/sandbox.rb
+++ b/lib/safer_rails_console/patches/railtie/sandbox.rb
@@ -6,8 +6,15 @@ module SaferRailsConsole
           def start(*args)
             options = args.last
 
-            options[:sandbox] = SaferRailsConsole.sandbox_environment? if options[:sandbox].nil?
-            options[:sandbox] = SaferRailsConsole::Console.sandbox_user_prompt if SaferRailsConsole.sandbox_environment? && SaferRailsConsole.config.sandbox_prompt
+            if options[:sandbox].nil?
+              options[:sandbox] = if options[:'read-only']
+                                    true
+                                  elsif options[:writable]
+                                    false
+                                  else
+                                    SaferRailsConsole.sandbox_environment? && SaferRailsConsole.config.sandbox_prompt ? SaferRailsConsole::Console.sandbox_user_prompt : SaferRailsConsole.sandbox_environment?
+                                  end
+            end
 
             super *args
           end

--- a/spec/integration/consoles/irb_spec.rb
+++ b/spec/integration/consoles/irb_spec.rb
@@ -25,8 +25,8 @@ describe "Integration: consoles/irb" do
       cmd.stdout
     end
 
-    it "displays '(unsandboxed)'" do
-      expect(cmd_stdout).to include('(unsandboxed)')
+    it "displays '(writable)'" do
+      expect(cmd_stdout).to include('(writable)')
     end
   end
 
@@ -37,8 +37,8 @@ describe "Integration: consoles/irb" do
       cmd.stdout
     end
 
-    it "displays '(sandboxed)'" do
-      expect(cmd_stdout).to include('(sandboxed)')
+    it "displays '(read-only)'" do
+      expect(cmd_stdout).to include('(read-only)')
     end
   end
 end

--- a/spec/integration/patches/boot_spec.rb
+++ b/spec/integration/patches/boot_spec.rb
@@ -6,12 +6,15 @@ describe "Integration: patches/boot" do
       cmd.stdout
     end
 
-    it "adds a --no-sandbox flag to 'rails console'" do
+    it "adds relevant flags to 'rails console'" do
       if SaferRailsConsole::RailsVersion.five_one?
         expect(cmd_stdout).to include('--no-sandbox')
       else
         expect(cmd_stdout).to include('--[no-]sandbox')
       end
+
+      expect(cmd_stdout).to include('--read-only')
+      expect(cmd_stdout).to include('--writable')
     end
 
     context "--no-sandbox" do
@@ -35,6 +38,30 @@ describe "Integration: patches/boot" do
 
       it "explicitly enables the sandbox if it is not enabled automatically" do
         expect(cmd_stdout).to include('Any modifications you make will be rolled back on exit')
+      end
+    end
+
+    context "--read-only" do
+      let(:cmd_stdout) do
+        cmd = Mixlib::ShellOut.new("#{@rails_cmd} console --read-only", env: @rails_env.merge(RAILS_ENV: 'development'), input: 'exit')
+        cmd.run_command
+        cmd.stdout
+      end
+
+      it "explicitly enables the sandbox if it is not enabled automatically" do
+        expect(cmd_stdout).to include('Any modifications you make will be rolled back on exit')
+      end
+    end
+
+    context "--writable" do
+      let(:cmd_stdout) do
+        cmd = Mixlib::ShellOut.new("#{@rails_cmd} console --writable", env: @rails_env.merge(RAILS_ENV: 'production'), input: 'exit')
+        cmd.run_command
+        cmd.stdout
+      end
+
+      it "explicitly disables the sandbox if it would be enabled automatically" do
+        expect(cmd_stdout).not_to include('Any modifications you make will be rolled back on exit')
       end
     end
   end


### PR DESCRIPTION
Given unclear messaging per #17 , the command line prompt should have a more easily understood message.

This fixes #17 .

prime: @cjf2xn 