### PR TITLE
Set DB transactions to read-only and provide messaging for non-read operations

### DIFF
--- a/lib/safer_rails_console/patches/sandbox/auto_rollback.rb
+++ b/lib/safer_rails_console/patches/sandbox/auto_rollback.rb
@@ -12,7 +12,7 @@ module SaferRailsConsole
 
         def self.handle_and_reraise_exception(e)
           if e.message.include?('PG::ReadOnlySqlTransaction')
-            puts color_text('An operation could not be completed due to read-only mode.', RED)
+            puts color_text('An operation could not be completed due to read-only mode.', RED) # rubocop:disable Rails/Output
           else
             rollback_and_begin_new_transaction
           end

--- a/lib/safer_rails_console/patches/sandbox/auto_rollback.rb
+++ b/lib/safer_rails_console/patches/sandbox/auto_rollback.rb
@@ -2,10 +2,22 @@ module SaferRailsConsole
   module Patches
     module Sandbox
       module AutoRollback
+        extend SaferRailsConsole::Colors
+
         def self.rollback_and_begin_new_transaction
           connection = ::ActiveRecord::Base.connection
           connection.rollback_db_transaction
           connection.begin_db_transaction
+        end
+
+        def self.handle_and_reraise_exception(e)
+          if e.message.include?('PG::ReadOnlySqlTransaction')
+            puts color_text('An operation could not be completed due to read-only mode.', RED)
+          else
+            rollback_and_begin_new_transaction
+          end
+
+          raise e
         end
 
         module ActiveRecord
@@ -14,15 +26,13 @@ module SaferRailsConsole
               def exec_no_cache(sql, name, binds)
                 super
               rescue => e
-                SaferRailsConsole::Patches::Sandbox::AutoRollback.rollback_and_begin_new_transaction
-                raise e
+                SaferRailsConsole::Patches::Sandbox::AutoRollback.handle_and_reraise_exception(e)
               end
 
               def exec_cache(sql, name, binds)
                 super
               rescue => e
-                SaferRailsConsole::Patches::Sandbox::AutoRollback.rollback_and_begin_new_transaction
-                raise e
+                SaferRailsConsole::Patches::Sandbox::AutoRollback.handle_and_reraise_exception(e)
               end
             end
 
@@ -30,8 +40,7 @@ module SaferRailsConsole
               def execute_and_clear(sql, name, binds)
                 super
               rescue => e
-                SaferRailsConsole::Patches::Sandbox::AutoRollback.rollback_and_begin_new_transaction
-                raise e
+                SaferRailsConsole::Patches::Sandbox::AutoRollback.handle_and_reraise_exception(e)
               end
             end
 
@@ -39,8 +48,7 @@ module SaferRailsConsole
               def execute_and_clear(sql, name, binds, prepare: false)
                 super
               rescue => e
-                SaferRailsConsole::Patches::Sandbox::AutoRollback.rollback_and_begin_new_transaction
-                raise e
+                SaferRailsConsole::Patches::Sandbox::AutoRollback.handle_and_reraise_exception(e)
               end
             end
           end

--- a/lib/safer_rails_console/patches/sandbox/transaction_read_only.rb
+++ b/lib/safer_rails_console/patches/sandbox/transaction_read_only.rb
@@ -1,0 +1,26 @@
+module SaferRailsConsole
+  module Patches
+    module Sandbox
+      module TransactionReadOnly
+        module ActiveRecord
+          module ConnectionAdapters
+            module PostgreSQLAdapter
+              def begin_db_transaction
+                super
+                execute "SET TRANSACTION READ ONLY"
+              end
+            end
+          end
+        end
+      end
+    end
+  end
+end
+
+if defined?(::ActiveRecord::ConnectionAdapters::PostgreSQLAdapter)
+  ::ActiveRecord::ConnectionAdapters::PostgreSQLAdapter.prepend(SaferRailsConsole::Patches::Sandbox::TransactionReadOnly::ActiveRecord::ConnectionAdapters::PostgreSQLAdapter)
+
+  # Ensure transaction is read-only if it was began before this patch was loaded
+  connection = ::ActiveRecord::Base.connection
+  connection.execute "SET TRANSACTION READ ONLY" if connection.open_transactions > 0
+end

--- a/lib/safer_rails_console/patches/sandbox/transaction_read_only.rb
+++ b/lib/safer_rails_console/patches/sandbox/transaction_read_only.rb
@@ -7,7 +7,7 @@ module SaferRailsConsole
             module PostgreSQLAdapter
               def begin_db_transaction
                 super
-                execute "SET TRANSACTION READ ONLY"
+                execute 'SET TRANSACTION READ ONLY'
               end
             end
           end
@@ -22,5 +22,5 @@ if defined?(::ActiveRecord::ConnectionAdapters::PostgreSQLAdapter)
 
   # Ensure transaction is read-only if it was began before this patch was loaded
   connection = ::ActiveRecord::Base.connection
-  connection.execute "SET TRANSACTION READ ONLY" if connection.open_transactions > 0
+  connection.execute 'SET TRANSACTION READ ONLY' if connection.open_transactions > 0
 end

--- a/spec/integration/patches/sandbox_spec.rb
+++ b/spec/integration/patches/sandbox_spec.rb
@@ -22,4 +22,22 @@ describe "Integration: patches/sandbox" do
       end
     end
   end
+
+  context "read_only" do
+    let(:console_commands) { ['Model.create!', 'exit'] }
+
+    it "enforces a read_only transaction and lets the user know that an operation could not be completed" do
+      # Currently, postgres is used for CI and local development is done against SQLite3
+      # TODO: Use 'dotenv' to allow developers to specify a database type
+      if ENV['CI']
+        expect(cmd[:stderr]).to include('SET TRANSACTION READ ONLY')
+        expect(cmd[:stdout]).to include('ActiveRecord::StatementInvalid')
+        expect(cmd[:stdout]).to include('An operation could not be completed due to read-only mode.')
+      else
+        expect(cmd[:stderr]).not_to include('SET TRANSACTION READ ONLY')
+        expect(cmd[:stdout]).not_to include('ActiveRecord::StatementInvalid')
+        expect(cmd[:stdout]).not_to include('An operation could not be completed due to read-only mode.')
+      end
+    end
+  end
 end


### PR DESCRIPTION
This fixes #18 and also fixes #19 , where transactions are always read-only in sandbox (read-only) mode.  Clearer messaging is added when a user tries to make a non-read operation.

<img width="1063" alt="screen shot 2017-09-01 at 4 33 03 pm" src="https://user-images.githubusercontent.com/5582810/29986853-40e70cde-8f33-11e7-9576-67273b9157ac.png">

prime: @cjf2xn 