### PR TITLE
Fix 'undefined constant RED' error + add tests

### DIFF
--- a/lib/safer_rails_console/patches/sandbox/auto_rollback.rb
+++ b/lib/safer_rails_console/patches/sandbox/auto_rollback.rb
@@ -12,7 +12,7 @@ module SaferRailsConsole
 
         def self.handle_and_reraise_exception(e)
           if e.message.include?('PG::ReadOnlySqlTransaction')
-            puts color_text('An operation could not be completed due to read-only mode.', RED) # rubocop:disable Rails/Output
+            puts color_text('An operation could not be completed due to read-only mode.', Colors::RED) # rubocop:disable Rails/Output
           else
             rollback_and_begin_new_transaction
           end

--- a/spec/safer_rails_console/patches/sandbox/auto_rollback_spec.rb
+++ b/spec/safer_rails_console/patches/sandbox/auto_rollback_spec.rb
@@ -1,0 +1,45 @@
+# require 'safer_rails_console/patches/sandbox/auto_rollback'
+
+describe "::SaferRailsConsole::Patches::Sandbox::AutoRollback" do
+  describe ".handle_and_reraise_exception" do
+    let(:mocked_ar_connection) { spy('ar_connection') } # rubocop:disable RSpec/VerifiedDoubles
+
+    # mock ActiveRecord::Base.connection
+    before do
+      ::SaferRailsConsole::Console.initialize_sandbox
+      module ActiveRecord
+        module Base
+        end
+      end
+      allow(::ActiveRecord::Base).to receive(:connection).and_return(mocked_ar_connection)
+    end
+
+    after do
+      Object.send(:remove_const, :ActiveRecord)
+    end
+
+    context "when raising a PG::ReadOnlySqlTransaction exception" do
+      let(:error) { RuntimeError.new('Beware of the PG::ReadOnlySqlTransaction exception!') }
+
+      it "outputs a message on stdout and forwards the exception" do
+        expect do
+          ::SaferRailsConsole::Patches::Sandbox::AutoRollback.handle_and_reraise_exception(error)
+        end.to raise_exception(error)
+           .and output(/An operation could not be completed due to read-only mode./).to_stdout
+      end
+    end
+
+    context "when raising a classic exception" do
+      let(:error) { RuntimeError.new('normal error') }
+
+      it "rollbacks, begins a new transaction and forwards the exception" do
+        expect do
+          ::SaferRailsConsole::Patches::Sandbox::AutoRollback.handle_and_reraise_exception(error)
+        end.to raise_exception(error)
+
+        expect(mocked_ar_connection).to have_received(:rollback_db_transaction).ordered
+        expect(mocked_ar_connection).to have_received(:begin_db_transaction).ordered
+      end
+    end
+  end
+end


### PR DESCRIPTION
I just got this error while using safer_rails_console today in development:
```
NameError: uninitialized constant SaferRailsConsole::Patches::Sandbox::AutoRollback::RED
from /home/cbliard/.rbenv/versions/2.5.3/lib/ruby/gems/2.5.0/gems/safer_rails_console-0.3.0/lib/safer_rails_console/patches/sandbox/auto_rollback.rb:15:in `handle_and_reraise_exception'
``` 

This PR should fix the error.

Tests added:

::SaferRailsConsole::Patches::Sandbox::AutoRollback
  .handle_and_reraise_exception
    when raising a PG::ReadOnlySqlTransaction exception
      outputs a message on stdout and forwards the exception
    when raising a classic exception
      rollbacks, begins a new transaction and forwards the exception

Please note that the first test in `spec/safer_rails_console/console_spec.rb` only passes because it is run before the tests I just added: I needed to load `::SaferRailsConsole::Patches::Sandbox::AutoRollback` to test `handle_and_reraise_exception` method, but it makes the test "SaferRailsConsole::Console.initialize_sandbox loads sandbox patches" fail if it is run afterwards (Because it checks that the patch is not loaded before calling `initialize_sandbox`). That makes the test order-dependent and that's bad. Happy to fix it if you have some guidance here.