### PR TITLE
Use Postgres for local development too

### DIFF
--- a/Appraisals
+++ b/Appraisals
@@ -1,5 +1,4 @@
 appraise '5.0' do
-  gem 'sqlite3', '~> 1.3.13'
   gem 'rails', '~> 5.0.0'
 end
 

--- a/gemfiles/5.0.gemfile
+++ b/gemfiles/5.0.gemfile
@@ -2,7 +2,6 @@
 
 source "https://rubygems.org"
 
-gem "sqlite3", "~> 1.3.13"
 gem "rails", "~> 5.0.0"
 
 gemspec path: "../"

--- a/safer_rails_console.gemspec
+++ b/safer_rails_console.gemspec
@@ -38,7 +38,6 @@ Gem::Specification.new do |spec|
   spec.add_development_dependency 'rake', '~> 12.0'
   spec.add_development_dependency 'rspec', '~> 3.6'
   spec.add_development_dependency 'salsify_rubocop', '~> 0.48.0'
-  spec.add_development_dependency 'sqlite3', '~> 1.4'
   spec.add_development_dependency 'wwtd', '~> 1.3'
   spec.add_runtime_dependency 'rails', '>= 5.0', '< 6.1'
 end

--- a/spec/integration/patches/sandbox_spec.rb
+++ b/spec/integration/patches/sandbox_spec.rb
@@ -21,13 +21,7 @@ describe "Integration: patches/sandbox" do
 
     it "lets the user know that an operation could not be completed" do
       results = run_console('Model.create!')
-      # Currently, postgres is used for CI and local development is done against SQLite3
-      # TODO: We should get these warnings for all types databases not just postgres
-      if ENV['CI']
-        expect(results[:stdout]).to include('An operation could not be completed due to read-only mode.')
-      else
-        expect(results[:stdout]).not_to include('An operation could not be completed due to read-only mode.')
-      end
+      expect(results[:stdout]).to include('An operation could not be completed due to read-only mode.')
     end
   end
 

--- a/spec/internal/database.yml.travis
+++ b/spec/internal/database.yml.travis
@@ -13,4 +13,4 @@ test:
 
 production:
   <<: *default
-  database: travis_ci_test
+  database: travis_ci_production

--- a/spec/internal/rails_5_0/Gemfile
+++ b/spec/internal/rails_5_0/Gemfile
@@ -2,6 +2,5 @@ source 'https://rubygems.org'
 
 gem 'pg'
 gem 'rails', '~> 5.0.4'
-gem 'sqlite3'
 
 gem 'safer_rails_console', path: '../../../'

--- a/spec/internal/rails_5_0/config/database.yml
+++ b/spec/internal/rails_5_0/config/database.yml
@@ -1,25 +1,16 @@
-# SQLite version 3.x
-#   gem install sqlite3
-#
-#   Ensure the SQLite 3 gem is defined in your Gemfile
-#   gem 'sqlite3'
-#
 default: &default
-  adapter: sqlite3
+  adapter: postgresql
   pool: 5
   timeout: 5000
 
 development:
   <<: *default
-  database: db/development.sqlite3
+  database: safer_rails_console_development
 
-# Warning: The database defined as "test" will be erased and
-# re-generated from your development database when you run "rake".
-# Do not set this db to the same as development or production.
 test:
   <<: *default
-  database: db/test.sqlite3
+  database: safer_rails_console_test
 
 production:
   <<: *default
-  database: db/production.sqlite3
+  database: safer_rails_console_production

--- a/spec/internal/rails_5_1/Gemfile
+++ b/spec/internal/rails_5_1/Gemfile
@@ -2,6 +2,5 @@ source 'https://rubygems.org'
 
 gem 'pg'
 gem 'rails', '~> 5.1.1'
-gem 'sqlite3'
 
 gem 'safer_rails_console', path: '../../../'

--- a/spec/internal/rails_5_1/config/database.yml
+++ b/spec/internal/rails_5_1/config/database.yml
@@ -1,25 +1,16 @@
-# SQLite version 3.x
-#   gem install sqlite3
-#
-#   Ensure the SQLite 3 gem is defined in your Gemfile
-#   gem 'sqlite3'
-#
 default: &default
-  adapter: sqlite3
-  pool: <%= ENV.fetch("RAILS_MAX_THREADS") { 5 } %>
+  adapter: postgresql
+  pool: 5
   timeout: 5000
 
 development:
   <<: *default
-  database: db/development.sqlite3
+  database: safer_rails_console_development
 
-# Warning: The database defined as "test" will be erased and
-# re-generated from your development database when you run "rake".
-# Do not set this db to the same as development or production.
 test:
   <<: *default
-  database: db/test.sqlite3
+  database: safer_rails_console_test
 
 production:
   <<: *default
-  database: db/production.sqlite3
+  database: safer_rails_console_production

--- a/spec/internal/rails_5_2/Gemfile
+++ b/spec/internal/rails_5_2/Gemfile
@@ -2,6 +2,5 @@ source 'https://rubygems.org'
 
 gem 'pg'
 gem 'rails', '~> 5.2.0'
-gem 'sqlite3'
 
 gem 'safer_rails_console', path: '../../../'

--- a/spec/internal/rails_5_2/config/database.yml
+++ b/spec/internal/rails_5_2/config/database.yml
@@ -1,25 +1,16 @@
-# SQLite version 3.x
-#   gem install sqlite3
-#
-#   Ensure the SQLite 3 gem is defined in your Gemfile
-#   gem 'sqlite3'
-#
 default: &default
-  adapter: sqlite3
-  pool: <%= ENV.fetch("RAILS_MAX_THREADS") { 5 } %>
+  adapter: postgresql
+  pool: 5
   timeout: 5000
 
 development:
   <<: *default
-  database: db/development.sqlite3
+  database: safer_rails_console_development
 
-# Warning: The database defined as "test" will be erased and
-# re-generated from your development database when you run "rake".
-# Do not set this db to the same as development or production.
 test:
   <<: *default
-  database: db/test.sqlite3
+  database: safer_rails_console_test
 
 production:
   <<: *default
-  database: db/production.sqlite3
+  database: safer_rails_console_production

--- a/spec/internal/rails_6_0/Gemfile
+++ b/spec/internal/rails_6_0/Gemfile
@@ -2,6 +2,5 @@ source 'https://rubygems.org'
 
 gem 'pg'
 gem 'rails', '~> 6.0.0'
-gem 'sqlite3'
 
 gem 'safer_rails_console', path: '../../../'

--- a/spec/internal/rails_6_0/config/database.yml
+++ b/spec/internal/rails_6_0/config/database.yml
@@ -1,25 +1,16 @@
-# SQLite version 3.x
-#   gem install sqlite3
-#
-#   Ensure the SQLite 3 gem is defined in your Gemfile
-#   gem 'sqlite3'
-#
 default: &default
-  adapter: sqlite3
-  pool: <%= ENV.fetch("RAILS_MAX_THREADS") { 5 } %>
+  adapter: postgresql
+  pool: 5
   timeout: 5000
 
 development:
   <<: *default
-  database: db/development.sqlite3
+  database: safer_rails_console_development
 
-# Warning: The database defined as "test" will be erased and
-# re-generated from your development database when you run "rake".
-# Do not set this db to the same as development or production.
 test:
   <<: *default
-  database: db/test.sqlite3
+  database: safer_rails_console_test
 
 production:
   <<: *default
-  database: db/production.sqlite3
+  database: safer_rails_console_production

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -13,7 +13,8 @@ RSpec.configure do |config|
   rails_root = File.join(RSpec::Core::RubyProject.root, 'spec', 'internal', "rails_#{::Rails.version[0..2].tr('.', '_')}")
 
   config.before :suite do
-    system("cd #{rails_root} && rake db:drop && rake db:setup && rake db:test:prepare")
+    system!("export RAILS_ENV=development && cd #{rails_root} && rake db:drop && rake db:setup && rake db:test:prepare")
+    system!("export RAILS_ENV=production && cd #{rails_root} && rake db:drop && rake db:setup && rake db:test:prepare")
   end
 
   config.before :all do
@@ -24,5 +25,11 @@ RSpec.configure do |config|
 
   config.before :each do
     allow(::Rails).to receive(:env).and_return(ActiveSupport::StringInquirer.new('development'))
+  end
+
+  def system!(command)
+    unless system(command)
+      raise "Command failed with exit code #{$CHILD_STATUS}: #{command}"
+    end
   end
 end


### PR DESCRIPTION
This change moves locally testing to use Postgres. Previously we were using Postgres in CI and sqlite locally which made troubleshooting CI issues difficult.

@atsheehan - you're prime