### PR TITLE
Add support for config values from ENV variables

### DIFF
--- a/README.md
+++ b/README.md
@@ -73,6 +73,24 @@ config.safer_rails_console.warn_text = "WARNING: YOU ARE USING RAILS CONSOLE IN 
                                        'Make sure you know what you\'re doing.'
 ```
 
+configuration settings can also be overridden using ENV variables. The following ENV vars can be used:
+```
+# Set the color prompt to a new color. See colors.rb for a listing of supported colors.
+SAFER_RAILS_CONSOLE_PROMPT_COLOR=red/yellow/green
+
+# Set the short name for the rails console prompt
+SAFER_RAILS_CONSOLE_ENVIRONMENT_NAME=short-name
+
+# Set the warning text to be displayed when warning for the environments rails consoled is enabled
+SAFER_RAILS_CONSOLE_WARN_TEXT=New warning prompt text
+
+# Enable or disable sandboxing of the rails console
+SAFER_RAILS_CONSOLE_SANDBOX_ENVIRONMENT=true/false
+
+# Enable or disable warning prompt of the rails console
+SAFER_RAILS_CONSOLE_WARN_ENVIRONMENT=true/false
+```
+
 ## Development
 
 After checking out the repo, run `bin/setup` to install dependencies. Then, run `rake spec` to run the tests. You can also run `wwtd` to simulate the entire build matrix (ruby version / rails version) or `appraisal` to test against each supported rails version with your active ruby version. Run `rubocop` to check for style. 

--- a/lib/safer_rails_console.rb
+++ b/lib/safer_rails_console.rb
@@ -38,7 +38,7 @@ module SaferRailsConsole
         config.warn_environments.include?(::Rails.env.downcase)
       end
     end
-    
+
     def warn_text
       if ENV.key?('SAFER_RAILS_CONSOLE_WARN_TEXT')
         ENV['SAFER_RAILS_CONSOLE_WARN_TEXT']

--- a/lib/safer_rails_console.rb
+++ b/lib/safer_rails_console.rb
@@ -3,23 +3,48 @@ require 'safer_rails_console/railtie'
 require 'safer_rails_console/colors'
 require 'safer_rails_console/rails_version'
 require 'safer_rails_console/console'
+require 'active_model/type'
 
 module SaferRailsConsole
   class << self
     def environment_name
-      config.environment_names.key?(::Rails.env.downcase) ? config.environment_names[::Rails.env.downcase] : 'unknown env'
+      if ENV.key?('SAFER_RAILS_CONSOLE_ENVIRONMENT_NAME')
+        ENV['SAFER_RAILS_CONSOLE_ENVIRONMENT_NAME']
+      else
+        config.environment_names.key?(::Rails.env.downcase) ? config.environment_names[::Rails.env.downcase] : 'unknown env'
+      end
     end
 
     def prompt_color
-      config.environment_prompt_colors.key?(::Rails.env.downcase) ? config.environment_prompt_colors[::Rails.env.downcase] : SaferRailsConsole::Colors::NONE
+      if ENV.key?('SAFER_RAILS_CONSOLE_PROMPT_COLOR')
+        SaferRailsConsole::Colors.const_get(ENV['SAFER_RAILS_CONSOLE_PROMPT_COLOR'].upcase)
+      else
+        config.environment_prompt_colors.key?(::Rails.env.downcase) ? config.environment_prompt_colors[::Rails.env.downcase] : SaferRailsConsole::Colors::NONE
+      end
     end
 
     def sandbox_environment?
-      config.sandbox_environments.include?(::Rails.env.downcase)
+      if ENV.key?('SAFER_RAILS_CONSOLE_SANDBOX_ENVIRONMENT')
+        ActiveModel::Type::Boolean.new.cast(ENV['SAFER_RAILS_CONSOLE_SANDBOX_ENVIRONMENT'])
+      else
+        config.sandbox_environments.include?(::Rails.env.downcase)
+      end
     end
 
     def warn_environment?
-      config.warn_environments.include?(::Rails.env.downcase)
+      if ENV.key?('SAFER_RAILS_CONSOLE_WARN_ENVIRONMENT')
+        ActiveModel::Type::Boolean.new.cast(ENV['SAFER_RAILS_CONSOLE_WARN_ENVIRONMENT'])
+      else
+        config.warn_environments.include?(::Rails.env.downcase)
+      end
+    end
+    
+    def warn_text
+      if ENV.key?('SAFER_RAILS_CONSOLE_WARN_TEXT')
+        ENV['SAFER_RAILS_CONSOLE_WARN_TEXT']
+      else
+        config.warn_text
+      end
     end
 
     def config

--- a/lib/safer_rails_console/console.rb
+++ b/lib/safer_rails_console/console.rb
@@ -8,7 +8,7 @@ module SaferRailsConsole
       end
 
       def print_warning
-        puts color_text(SaferRailsConsole.config.warn_text, SaferRailsConsole.prompt_color) # rubocop:disable Rails/Output
+        puts color_text(SaferRailsConsole.warn_text, SaferRailsConsole.prompt_color) # rubocop:disable Rails/Output
       end
 
       def load_config

--- a/safer_rails_console.gemspec
+++ b/safer_rails_console.gemspec
@@ -32,6 +32,7 @@ Gem::Specification.new do |spec|
 
   spec.add_development_dependency 'appraisal', '~> 2.2'
   spec.add_development_dependency 'bundler', '~> 2.0'
+  spec.add_development_dependency 'climate_control', '~> 0.2.0'
   spec.add_development_dependency 'mixlib-shellout', '~> 2.2'
   spec.add_development_dependency 'overcommit', '~> 0.39.0'
   spec.add_development_dependency 'pg', '~> 1.1'

--- a/spec/safer_rails_console_spec.rb
+++ b/spec/safer_rails_console_spec.rb
@@ -49,5 +49,27 @@ describe SaferRailsConsole do
       described_class.config.set(sandbox_prompt: true)
       expect(described_class.config.sandbox_prompt).to eq(true)
     end
+
+    it "#set with ENV vars" do
+      with_modified_env SAFER_RAILS_CONSOLE_WARN_TEXT: 'warn-text',
+      SAFER_RAILS_CONSOLE_ENVIRONMENT_NAME: 'short-name',
+      SAFER_RAILS_CONSOLE_WARN_ENVIRONMENT: 'true',
+      SAFER_RAILS_CONSOLE_SANDBOX_ENVIRONMENT: 'true',
+      SAFER_RAILS_CONSOLE_PROMPT_COLOR: 'red' do
+        expect(described_class.warn_text).to eq('warn-text')
+        expect(described_class.environment_name).to eq('short-name')
+        expect(described_class.warn_environment?).to eq(true)
+        expect(described_class.sandbox_environment?).to eq(true)
+        expect(described_class.prompt_color).to eq(31)
+      end
+    end
+
+    it "#set with false ENV vars" do
+      with_modified_env SAFER_RAILS_CONSOLE_WARN_ENVIRONMENT: 'false',
+      SAFER_RAILS_CONSOLE_SANDBOX_ENVIRONMENT: 'false' do
+        expect(described_class.warn_environment?).to eq(false)
+        expect(described_class.sandbox_environment?).to eq(false)
+      end
+    end
   end
 end

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -1,4 +1,5 @@
 require 'bundler/setup'
+require 'climate_control'
 require 'mixlib/shellout'
 require 'safer_rails_console'
 
@@ -25,6 +26,10 @@ RSpec.configure do |config|
 
   config.before :each do
     allow(::Rails).to receive(:env).and_return(ActiveSupport::StringInquirer.new('development'))
+  end
+
+  def with_modified_env(options, &block)
+    ClimateControl.modify(options, &block)
   end
 
   def system!(command)


### PR DESCRIPTION
This change adds support modifying specific configuration settings through ENV variables. Order of operations is still honored in this change, default values are set first, then ENV variables are used, and then application config is applied. 
 
Prime: @kphelps / @askreet 