### PR TITLE
Ruby 3 support

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -30,7 +30,7 @@ jobs:
       gemfile:
         type: string
     docker:
-      - image: salsify/ruby_ci:2.5.8
+      - image: salsify/ruby_ci:<< parameters.ruby_version >>
         environment:
           CIRCLE_TEST_REPORTS: "test-results"
           BUNDLE_GEMFILE: "/home/circleci/safer_rails_console/<< parameters.gemfile >>"
@@ -44,8 +44,8 @@ jobs:
       - checkout
       - restore_cache:
           keys:
-            - v2-gems-ruby-2.5.8-{{ checksum "safer_rails_console.gemspec" }}-{{ checksum "<< parameters.gemfile >>" }}
-            - v2-gems-ruby-2.5.8-
+            - v2-gems-ruby-<< parameters.ruby_version >>-{{ checksum "safer_rails_console.gemspec" }}-{{ checksum "<< parameters.gemfile >>" }}
+            - v2-gems-ruby-<< parameters.ruby_version >>-
       - run:
           name: Install Gems
           command: |
@@ -54,7 +54,7 @@ jobs:
               bundle clean
             fi
       - save_cache:
-          key: v2-gems-ruby-2.5.8-{{ checksum "safer_rails_console.gemspec" }}-{{ checksum "<< parameters.gemfile >>" }}
+          key: v2-gems-ruby-<< parameters.ruby_version >>-{{ checksum "safer_rails_console.gemspec" }}-{{ checksum "<< parameters.gemfile >>" }}
           paths:
             - "vendor/bundle"
             - "gemfiles/vendor/bundle"
@@ -69,6 +69,7 @@ workflows:
     jobs:
       - lint
       - test:
+          ruby_version: "2.5.8"
           matrix:
             parameters:
               gemfile:
@@ -77,3 +78,7 @@ workflows:
               - "gemfiles/5.2.gemfile"
               - "gemfiles/6.0.gemfile"
               - "gemfiles/6.1.gemfile"
+      - test:
+          name: 'ruby-3.0.0'
+          ruby_version: "3.0.0"
+          gemfile: "gemfiles/6.1.gemfile"

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -27,6 +27,8 @@ jobs:
           command: bundle exec rubocop
   test:
     parameters:
+      ruby_version:
+        type: string
       gemfile:
         type: string
     docker:

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,13 @@
 # Changelog
 
+## [v0.5.1](https://github.com/salsify/safer_rails_console/tree/v0.5.0) (2020-01-29)
+
+[Full Changelog](https://github.com/salsify/safer_rails_console/compare/v0.5.0...v0.5.1)
+
+**Merged pull requests:**
+
+- Ruby 3 Support [\#39](https://github.com/salsify/safer_rails_console/pull/39) ([kphelps](https://github.com/kphelps))
+
 ## [v0.5.0](https://github.com/salsify/safer_rails_console/tree/v0.5.0) (2020-12-15)
 
 [Full Changelog](https://github.com/salsify/safer_rails_console/compare/v0.4.1...v0.5.0)

--- a/lib/safer_rails_console/railtie.rb
+++ b/lib/safer_rails_console/railtie.rb
@@ -10,7 +10,7 @@ module SaferRailsConsole
     config.safer_rails_console = ActiveSupport::OrderedOptions.new
 
     initializer 'safer_rails_console.configure' do |app|
-      SaferRailsConsole.config.set(app.config.safer_rails_console)
+      SaferRailsConsole.config.set(**app.config.safer_rails_console)
     end
 
     config.after_initialize do

--- a/lib/safer_rails_console/version.rb
+++ b/lib/safer_rails_console/version.rb
@@ -1,5 +1,5 @@
 # frozen_string_literal: true
 
 module SaferRailsConsole
-  VERSION = '0.5.0'
+  VERSION = '0.5.1'
 end


### PR DESCRIPTION
This fixes one use of the deprecated keyword argument conversion. I also updated the circle CI configuration to add ruby 3 to the build matrix.

prime @jturkel