### PR TITLE
Add Rails 8.0 support

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -81,12 +81,15 @@ workflows:
       - test:
           matrix:
             parameters:
-              ruby_version:
-                - 3.1.4
-                - 3.2.2
-                - 3.3.0
               gemfile:
-                - gemfiles/6.1.gemfile
                 - gemfiles/7.0.gemfile
                 - gemfiles/7.1.gemfile
                 - gemfiles/7.2.gemfile
+                - gemfiles/8.0.gemfile
+              ruby_version:
+                - 3.1.5
+                - 3.2.4
+                - 3.3.4
+            exclude:
+              - gemfile: gemfiles/rails_8.0.gemfile
+                ruby_version: 3.1.5

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -91,5 +91,5 @@ workflows:
                 - 3.2.4
                 - 3.3.4
             exclude:
-              - gemfile: gemfiles/rails_8.0.gemfile
+              - gemfile: gemfiles/8.0.gemfile
                 ruby_version: 3.1.5

--- a/Appraisals
+++ b/Appraisals
@@ -1,9 +1,5 @@
 # frozen_string_literal: true
 
-appraise '6.1' do
-  gem 'rails', '~> 6.1.7.6'
-end
-
 appraise '7.0' do
   gem 'rails', '~> 7.0.8'
 end
@@ -14,4 +10,8 @@ end
 
 appraise '7.2' do
   gem 'rails', '~> 7.2.0'
+end
+
+appraise '8.0' do
+  gem 'rails', '~> 8.0.0'
 end

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Changelog
 
+## v0.11.0
+- Add support for Rails 8.0.
+- Drop support for Rails 6.1
+
 ## v0.10.0
 - Drop support for Ruby 3.0.
 - Add support for Rails 7.2. **Thanks [@kwent](https://github.com/kwent)**

--- a/gemfiles/8.0.gemfile
+++ b/gemfiles/8.0.gemfile
@@ -2,6 +2,6 @@
 
 source "https://rubygems.org"
 
-gem "rails", "~> 6.1.7.6"
+gem "rails", "~> 8.0.0"
 
 gemspec path: "../"

--- a/lib/safer_rails_console/version.rb
+++ b/lib/safer_rails_console/version.rb
@@ -1,5 +1,5 @@
 # frozen_string_literal: true
 
 module SaferRailsConsole
-  VERSION = '0.10.0'
+  VERSION = '0.11.0'
 end

--- a/safer_rails_console.gemspec
+++ b/safer_rails_console.gemspec
@@ -47,5 +47,5 @@ Gem::Specification.new do |spec|
   spec.add_development_dependency 'rspec_junit_formatter'
   spec.add_development_dependency 'salsify_rubocop', '~> 1.27.0'
 
-  spec.add_runtime_dependency 'rails', '>= 6.1', '< 7.3'
+  spec.add_runtime_dependency 'rails', '>= 7.0', '< 8.1'
 end


### PR DESCRIPTION
Adds Rails 8.0 support.
Pretty much a copy paste from [Activerecord-extensions's bump](https://github.com/salsify/activerecord-extensions/pull/117).