### PR TITLE
Support Ruby 4

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -13,8 +13,9 @@ jobs:
       - run:
           name: Install Gems
           command: |
-            if ! bundle check --path=vendor/bundle; then
-              bundle install --path=vendor/bundle --jobs=4 --retry=3
+            bundle config set path 'vendor/bundle'
+            if ! bundle check; then
+              bundle install --jobs=4 --retry=3
               bundle clean
             fi
       - save_cache:
@@ -56,8 +57,9 @@ jobs:
       - run:
           name: Install Gems
           command: |
-            if ! bundle check --path=vendor/bundle; then
-              bundle install --path=vendor/bundle --jobs=4 --retry=3
+            bundle config set path 'vendor/bundle'
+            if ! bundle check; then
+              bundle install --jobs=4 --retry=3
               bundle clean
             fi
       - save_cache:
@@ -85,6 +87,7 @@ workflows:
                 - 3.2.6
                 - 3.3.6
                 - 3.4.7
+                - 4.0.0
               gemfile:
                 - gemfiles/7.2.gemfile
                 - gemfiles/8.0.gemfile

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Changelog
 
+## v0.14.0
+
+- Add support for Ruby 4
+
 ## v0.13.0
 
 - Fix deprecation warning in Rails 8.1

--- a/lib/safer_rails_console/version.rb
+++ b/lib/safer_rails_console/version.rb
@@ -1,5 +1,5 @@
 # frozen_string_literal: true
 
 module SaferRailsConsole
-  VERSION = '0.13.0'
+  VERSION = '0.14.0'
 end

--- a/safer_rails_console.gemspec
+++ b/safer_rails_console.gemspec
@@ -47,6 +47,8 @@ Gem::Specification.new do |spec|
   spec.add_development_dependency 'rspec_junit_formatter'
   spec.add_development_dependency 'salsify_rubocop', '~> 1.27.0'
 
+  spec.add_runtime_dependency 'ostruct'
   spec.add_runtime_dependency 'rails', '>= 7.2', '< 8.2'
   spec.add_runtime_dependency 'readline'
+
 end

--- a/safer_rails_console.gemspec
+++ b/safer_rails_console.gemspec
@@ -48,4 +48,5 @@ Gem::Specification.new do |spec|
   spec.add_development_dependency 'salsify_rubocop', '~> 1.27.0'
 
   spec.add_runtime_dependency 'rails', '>= 7.2', '< 8.2'
+  spec.add_runtime_dependency 'readline'
 end

--- a/safer_rails_console.gemspec
+++ b/safer_rails_console.gemspec
@@ -36,7 +36,7 @@ Gem::Specification.new do |spec|
   spec.required_ruby_version = '>= 3.2'
 
   spec.add_development_dependency 'appraisal', '~> 2.2'
-  spec.add_development_dependency 'bundler', '~> 2.0'
+  spec.add_development_dependency 'bundler'
   spec.add_development_dependency 'climate_control', '~> 0.2.0'
   spec.add_development_dependency 'mixlib-shellout', '~> 2.2'
   spec.add_development_dependency 'mysql2', '~> 0.5'


### PR DESCRIPTION
- Add readline and ostruct to gemspec, as they are no longer bundled with Ruby 4
- Test with Ruby 4

Prime: @erikkessler1 
CC: @salsify/network-core 